### PR TITLE
fix: handle all possibilities with sonar event payloads

### DIFF
--- a/sonar/types.go
+++ b/sonar/types.go
@@ -17,7 +17,7 @@ package sonar
 // Event is...
 type Event struct {
 	TaskId      string            `json:"taskId"`
-	Status      string            `json:"status"`
+	Status      EventStatus       `json:"status"`
 	AnalysedAt  string            `json:"analysedAt"`
 	Revision    string            `json:"revision"`
 	Project     *Project          `json:"project"`
@@ -43,16 +43,18 @@ type Project struct {
 
 // QualityGate is...
 type QualityGate struct {
-	Conditions []*Condition      `json:"conditions"`
-	Name       string            `json:"name"`
-	Status     QualityGateStatus `json:"status"`
+	Conditions []*Condition `json:"conditions"`
+	Name       string       `json:"name"`
+	Status     EventStatus  `json:"status"`
 }
 
-type QualityGateStatus string
+type EventStatus string
 
 const (
-	STATUS_OK    QualityGateStatus = "OK"
-	STATUS_ERROR QualityGateStatus = "ERROR"
+	STATUS_SUCCESS EventStatus = "SUCCESS"
+	STATUS_OK      EventStatus = "OK"
+	STATUS_ERROR   EventStatus = "ERROR"
+	STATUS_FAILED  EventStatus = "FAILED"
 )
 
 // Condition is...


### PR DESCRIPTION
if the scan fails entirely, the payload doesn't include the quality gate info:

```json
{
  "serverUrl": "https://sonarqube.parker.gg",
  "taskId": "AXqwMJ7OayNBvdQS2iiJ",
  "status": "FAILED",
  "analysedAt": "2021-07-16T16:40:02+0000",
  "revision": "e6cbe594f606edc334408d70c9c97ee94af0fd35",
  "changedAt": "2021-07-16T16:40:02+0000",
  "project": {
    "key": "rode:demo-app",
    "name": "rode:demo-app",
    "url": "https://sonarqube.parker.gg/dashboard?id=rode%3Ademo-app"
  },
  "branch": {
    "name": "master",
    "type": "BRANCH",
    "isMain": true,
    "url": "https://sonarqube.parker.gg/dashboard?id=rode%3Ademo-app"
  },
  "properties": {
    "sonar.analysis.resourceUriPrefix": "github.com/rode/demo-app"
  }
}
```

looking for this while creating the note was causing nil pointer exceptions when the scan fails entirely